### PR TITLE
feat(mpris): Add `xesam:url` field (#2095)

### DIFF
--- a/src/electron/mpris.js
+++ b/src/electron/mpris.js
@@ -35,6 +35,7 @@ export function createMpris(window) {
       'xesam:title': metadata.title,
       'xesam:album': metadata.album,
       'xesam:artist': metadata.artist.split(','),
+      'xesam:url': metadata.url,
     };
   });
 

--- a/src/utils/Player.js
+++ b/src/utils/Player.js
@@ -666,6 +666,7 @@ export default class {
       ],
       length: this.currentTrackDuration,
       trackId: this.current,
+      url: '/trackid/' + track.id,
     };
 
     navigator.mediaSession.metadata = new window.MediaMetadata(metadata);


### PR DESCRIPTION
With this field, users could easily get NetEase song id from MPRIS2